### PR TITLE
brew.rb:  Undeprecate `HOMEBREW_BUILD_FROM_SOURCE`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -97,10 +97,6 @@ begin
     system(HOMEBREW_BREW_FILE, "uninstall", "--force", "brew-cask")
   end
 
-  if ENV["HOMEBREW_BUILD_FROM_SOURCE"]
-    odeprecated("HOMEBREW_BUILD_FROM_SOURCE", "--build-from-source")
-  end
-
   if internal_cmd
     Homebrew.send cmd.to_s.tr("-", "_").downcase
   elsif which "brew-#{cmd}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?  (Partly, see my commit message.)  
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).  
- [x] Have you successfully run `brew style` with your changes locally?  
- [ ] Have you successfully run `brew tests` with your changes locally?  (All tests pass locally except '`test/os/mac_spec.rb`,' which fails with an unrelated error stating that, "`'Locale::parse' failed to parse 'OS::Mac::language'`.")  

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I'm leaving this open for the time being instead of merging it immediately, at least until we formally decide on how to proceed with #2.  